### PR TITLE
Replaced shade with assembly plugin the com.musala.simple.students project.

### DIFF
--- a/com.musala.simple.students/pom.xml
+++ b/com.musala.simple.students/pom.xml
@@ -30,25 +30,26 @@
          </plugin>
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-shade-plugin</artifactId>
+            <artifactId>maven-assembly-plugin</artifactId>
             <version>3.1.0</version>
             <executions>
                <execution>
                   <phase>package</phase>
                   <goals>
-                     <goal>shade</goal>
+                     <goal>single</goal>
                   </goals>
                   <configuration>
-        		     <createDependencyReducedPom>false</createDependencyReducedPom>
-                     <transformers>
-                        <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                     <source>1.8</source>
+                     <target>1.8</target>
+                     <archive>
+                        <manifest>
                            <mainClass>com.musala.simple.students.Main</mainClass>
-                        </transformer>
-                     </transformers>
+                        </manifest>
+                     </archive>
                   </configuration>
                </execution>
             </executions>
-         </plugin>
+         </plugin>      
       </plugins>
    </build>
 </project>

--- a/com.musala.simple.students/pom.xml
+++ b/com.musala.simple.students/pom.xml
@@ -46,6 +46,9 @@
                            <mainClass>com.musala.simple.students.Main</mainClass>
                         </manifest>
                      </archive>
+                     <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                     </descriptorRefs>
                   </configuration>
                </execution>
             </executions>

--- a/com.musala.simple.students/pom.xml
+++ b/com.musala.simple.students/pom.xml
@@ -29,6 +29,16 @@
             </configuration>
          </plugin>
          <plugin>
+            <artifactId>maven-jar-plugin</artifactId>
+            <version>2.3.1</version>
+            <executions>
+               <execution>
+                     <id>default-jar</id>
+                     <phase>none</phase>
+               </execution>
+            </executions>
+        </plugin>
+         <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-assembly-plugin</artifactId>
             <version>3.1.0</version>


### PR DESCRIPTION
Changed the `pom.xml` file for the `com.musala.simple.students` project in such a way that:
- `maven-shade-plugin` is now removed and is replaced with `maven-assembly-plugin`.
- `maven-jar-plugin` used for removal of the default generated jar file.

@ionkoto please besides reviewing my PR try to build the `com.musala.simple.students` project and re-check if the generated artifact works as expected. When the PR gets merged, we will discuss how and when to apply the solution for the other projects (idea for the solution taken from http://www.baeldung.com/executable-jar-with-maven).